### PR TITLE
WIP: Non root support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,14 @@ RUN set -x; \
     && git submodule update --init VisualEditor \
     && cd VisualEditor \
     && git checkout $MEDIAWIKI_VERSION \
-    && git submodule update --init
+    && git submodule update --init \
+    && chmod 777 /var/www/html
+
+RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/apache2 \
+    && rm -rf /var/log/apache2 \
+    && ln -s /data/log /var/log/apache2 \
+    && chmod 777 /var/lock/apache2 \
+    && chmod 777 /var/run/apache2
 
 COPY php.ini /usr/local/etc/php/conf.d/mediawiki.ini
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -115,6 +115,8 @@ ln -s /usr/src/mediawiki/* .
 
 : ${MEDIAWIKI_SHARED:=/data}
 if [ -d "$MEDIAWIKI_SHARED" ]; then
+    mkdir -p "$MEDIAWIKI_SHARED/log"
+
 	# If there is no LocalSettings.php but we have one under the shared
 	# directory, symlink it
 	if [ -e "$MEDIAWIKI_SHARED/LocalSettings.php" -a ! -e LocalSettings.php ]; then
@@ -225,7 +227,7 @@ fi
 mkdir -p images
 
 # Fix file ownership and permissions
-chown -R www-data: .
-chmod 755 images
+#chown -R www-data: .
+#chmod 755 images
 
 exec "$@"


### PR DESCRIPTION
This patch adds support for running the container using an arbitrary user, via
`docker run -u <user>`.

Changes:
- Move log files to /data/log.
- Make /var/{lock,run}/apache2 world-writable.
  - TODO: Find a better way to do this? Start the container as root, but
    drop privileges based on the user / group that was passed in an env var?
- Make /var/www/html world-writable.
  - TODO: Get rid of the symlinking in the entry point script.
