### PR TITLE
enable link to $MEDIAWIKI_SHARED/extensions

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -131,7 +131,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 
 	# If an extensions folder exists inside the shared directory, as long as
 	# /var/www/html/extensions is not already a symbolic link, then replace it
-	if [ -d "$MEDIAWIKI_SHARED/extensions" -a ! -h /var/www/html/extensions ]; then
+	if [ -d "$MEDIAWIKI_SHARED/extensions" ]; then
 		echo >&2 "Found 'extensions' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/extensions
 		ln -s "$MEDIAWIKI_SHARED/extensions" /var/www/html/extensions


### PR DESCRIPTION
The extensions symbolic link always exists and is therefore never
replaced by $MEDIAWIKI_SHARED/extensions when it exists.

Signed-off-by: Loic Dachary loic@dachary.org
