### PR TITLE
Bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:sid
+FROM debian:jessie
 MAINTAINER Gabriel Wicke <gwicke@wikimedia.org>
 
 # Waiting in antiticipation for built-time arguments
 # https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION wmf/1.27.0-wmf.9
+ENV MEDIAWIKI_VERSION wmf/1.28.0-wmf.15
 
 # XXX: Consider switching to nginx.
 RUN set -x; \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -111,7 +111,7 @@ EOPHP
 
 cd /var/www/html
 # FIXME: Keep php files out of the doc root.
-ln -s /usr/src/mediawiki/* .
+ln -sf /usr/src/mediawiki/* .
 
 : ${MEDIAWIKI_SHARED:=/data}
 if [ -d "$MEDIAWIKI_SHARED" ]; then


### PR DESCRIPTION
- Fixed a bug that made the image crash on startup due to already created symlinks
- Corrected branch version name of 'mediawiki/core' project to point to an existing version
- changed FROM clause of Dockerfile to point to latest current stable Debian version
