### PR TITLE
A rollup merge of all the PRs, fixing the path & linking problems and the email problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Gabriel Wicke <gwicke@wikimedia.org>
 
 # Waiting in antiticipation for built-time arguments
 # https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION wmf/1.27.0-wmf.9
+ENV MEDIAWIKI_VERSION wmf/1.28.0-wmf.15
 
 # XXX: Consider switching to nginx.
 RUN set -x; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN set -x; \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/* \
     && a2enmod rewrite \
+    && a2enmod proxy \
+    && a2enmod proxy_http \
     # Remove the default Debian index page.
     && rm /var/www/html/index.html
 

--- a/apache/mediawiki.conf
+++ b/apache/mediawiki.conf
@@ -18,6 +18,10 @@ LimitRequestBody 220200960
   </VirtualHost>
 </IfModule>
 
+# Expose REST API at /api/rest_v1/
+ProxyPassInterpolateEnv On
+ProxyPass /api/rest_v1/ ${MEDIAWIKI_RESTBASE_URL}/ interpolate
+
 <Directory /var/www/html>
   # Use of .htaccess files exposes a lot of security risk,
   # disable them and put all the necessary configuration here instead.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -111,6 +111,9 @@ EOPHP
 
 cd /var/www/html
 # FIXME: Keep php files out of the doc root.
+
+# Force flag on ln, because this file is run everytime the container is restarted,
+# and if any of the links exists already, ln will return an error, and booting the image fails.
 ln -sf /usr/src/mediawiki/* .
 
 : ${MEDIAWIKI_SHARED:=/data}
@@ -121,33 +124,33 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 		ln -sf "$MEDIAWIKI_SHARED/LocalSettings.php" LocalSettings.php
 	fi
 
-	# If the images directory only contains a README, then link it to
+	# If the images directory only contains a README and is a link to /usr/src/mediawiki/images, then link it to
 	# $MEDIAWIKI_SHARED/images, creating the shared directory if necessary
-	if [ "$(ls images)" = "README" -a ! -L images ]; then
+	if [ "$(ls images)" = "README" -a "$(realpath images)" = "/usr/src/mediawiki/images" ]; then
 		rm -fr images
 		mkdir -p "$MEDIAWIKI_SHARED/images"
 		ln -sf "$MEDIAWIKI_SHARED/images" images
 	fi
 
-	# If an extensions folder exists inside the shared directory, as long as
-	# /var/www/html/extensions is not already a symbolic link, then replace it
-	if [ -d "$MEDIAWIKI_SHARED/extensions" -a ! -h /var/www/html/extensions ]; then
+	# If an extensions folder exists inside the shared directory, and
+	# /var/www/html/extensions a symbolic link to /usr/src/mediawiki/extensions, replace it
+	if [ -d "$MEDIAWIKI_SHARED/extensions" -a "$(realpath extensions)" = "/usr/src/mediawiki/extensions" ]; then
 		echo >&2 "Found 'extensions' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/extensions
 		ln -sf "$MEDIAWIKI_SHARED/extensions" /var/www/html/extensions
 	fi
 
 	# If a skins folder exists inside the shared directory, as long as
-	# /var/www/html/skins is not already a symbolic link, then replace it
-	if [ -d "$MEDIAWIKI_SHARED/skins" -a ! -h /var/www/html/skins ]; then
+	# /var/www/html/skins a symbolic link to /usr/src/mediawiki/skins, replace it
+	if [ -d "$MEDIAWIKI_SHARED/skins" -a "$(realpath skins)" = "/usr/src/mediawiki/skins" ]; then
 		echo >&2 "Found 'skins' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/skins
 		ln -sf "$MEDIAWIKI_SHARED/skins" /var/www/html/skins
 	fi
 
 	# If a vendor folder exists inside the shared directory, as long as
-	# /var/www/html/vendor is not already a symbolic link, then replace it
-	if [ -d "$MEDIAWIKI_SHARED/vendor" -a ! -h /var/www/html/vendor ]; then
+	# /var/www/html/vendor a symbolic link to /usr/src/mediawiki/vendor, replace it
+	if [ -d "$MEDIAWIKI_SHARED/vendor" -a "$(realpath vendor)" = "/usr/src/mediawiki/vendor" ]; then
 		echo >&2 "Found 'vendor' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/vendor
 		ln -sf "$MEDIAWIKI_SHARED/vendor" /var/www/html/vendor

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -111,14 +111,14 @@ EOPHP
 
 cd /var/www/html
 # FIXME: Keep php files out of the doc root.
-ln -s /usr/src/mediawiki/* .
+ln -sf /usr/src/mediawiki/* .
 
 : ${MEDIAWIKI_SHARED:=/data}
 if [ -d "$MEDIAWIKI_SHARED" ]; then
 	# If there is no LocalSettings.php but we have one under the shared
 	# directory, symlink it
 	if [ -e "$MEDIAWIKI_SHARED/LocalSettings.php" -a ! -e LocalSettings.php ]; then
-		ln -s "$MEDIAWIKI_SHARED/LocalSettings.php" LocalSettings.php
+		ln -sf "$MEDIAWIKI_SHARED/LocalSettings.php" LocalSettings.php
 	fi
 
 	# If the images directory only contains a README, then link it to
@@ -126,7 +126,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 	if [ "$(ls images)" = "README" -a ! -L images ]; then
 		rm -fr images
 		mkdir -p "$MEDIAWIKI_SHARED/images"
-		ln -s "$MEDIAWIKI_SHARED/images" images
+		ln -sf "$MEDIAWIKI_SHARED/images" images
 	fi
 
 	# If an extensions folder exists inside the shared directory, as long as
@@ -134,7 +134,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 	if [ -d "$MEDIAWIKI_SHARED/extensions" -a ! -h /var/www/html/extensions ]; then
 		echo >&2 "Found 'extensions' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/extensions
-		ln -s "$MEDIAWIKI_SHARED/extensions" /var/www/html/extensions
+		ln -sf "$MEDIAWIKI_SHARED/extensions" /var/www/html/extensions
 	fi
 
 	# If a skins folder exists inside the shared directory, as long as
@@ -142,7 +142,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 	if [ -d "$MEDIAWIKI_SHARED/skins" -a ! -h /var/www/html/skins ]; then
 		echo >&2 "Found 'skins' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/skins
-		ln -s "$MEDIAWIKI_SHARED/skins" /var/www/html/skins
+		ln -sf "$MEDIAWIKI_SHARED/skins" /var/www/html/skins
 	fi
 
 	# If a vendor folder exists inside the shared directory, as long as
@@ -150,7 +150,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 	if [ -d "$MEDIAWIKI_SHARED/vendor" -a ! -h /var/www/html/vendor ]; then
 		echo >&2 "Found 'vendor' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/vendor
-		ln -s "$MEDIAWIKI_SHARED/vendor" /var/www/html/vendor
+		ln -sf "$MEDIAWIKI_SHARED/vendor" /var/www/html/vendor
 	fi
 
 	# Attempt to enable SSL support if explicitly requested
@@ -199,7 +199,7 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 		if [ -d "$MEDIAWIKI_SHARED" ]; then
 			# Move generated LocalSettings.php to share volume
 			mv LocalSettings.php "$MEDIAWIKI_SHARED/LocalSettings.php"
-			ln -s "$MEDIAWIKI_SHARED/LocalSettings.php" LocalSettings.php
+			ln -sf "$MEDIAWIKI_SHARED/LocalSettings.php" LocalSettings.php
 		fi
 fi
 


### PR DESCRIPTION
Rolled up this
https://github.com/wikimedia/mediawiki-docker/pull/6
and this
https://github.com/wikimedia/mediawiki-docker/pull/2
pull request, plus introduced a commit fixing the `extensions`, `skins`, and `vendor` linking problems. This fixes also the problem stated by this PR: https://github.com/wikimedia/mediawiki-docker/pull/3

I hope this (or the other PRs) will be pulled in soon, as currently one needs quite a bit of fiddling to get this image to work.
