### PR TITLE
Change proxying method from ProxyPass to RewriteRule

### DIFF
--- a/apache/mediawiki.conf
+++ b/apache/mediawiki.conf
@@ -19,8 +19,9 @@ LimitRequestBody 220200960
 </IfModule>
 
 # Expose REST API at /api/rest_v1/
-ProxyPassInterpolateEnv On
-ProxyPass /api/rest_v1/ ${MEDIAWIKI_RESTBASE_URL}/ interpolate
+RewriteEngine On
+RewriteCond ${MEDIAWIKI_RESTBASE_URL} "!^restbase-is-not-specified$"
+RewriteRule "^/api/rest_v1/(.*)$"  "${MEDIAWIKI_RESTBASE_URL}/$1"  [P]
 
 <Directory /var/www/html>
   # Use of .htaccess files exposes a lot of security risk,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,10 @@ if [ -z "$MEDIAWIKI_DB_HOST" ]; then
 	fi
 fi
 
+if [ -z "$MEDIAWIKI_RESTBASE_URL" ]; then
+	export MEDIAWIKI_RESTBASE_URL=restbase-is-not-specified
+fi
+
 if [ -z "$MEDIAWIKI_DB_USER" ]; then
 	if [ "$MEDIAWIKI_DB_TYPE" = "mysql" ]; then
 		echo >&2 'info: missing MEDIAWIKI_DB_USER environment variable, defaulting to "root"'


### PR DESCRIPTION
Change proxying method from `ProxyPass` to `RewriteRule`
and add MEDIAWIKI_RESTBASE_URL environment variable check
to 'docker-entrypoint.sh' to avoid "AH00111: Config variable
${MEDIAWIKI_RESTBASE_URL} is not defined" apache
error.