### PR TITLE
Separate RESTBase apache ProxyPass configuration to a new file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN set -x; \
 COPY php.ini /usr/local/etc/php/conf.d/mediawiki.ini
 
 COPY apache/mediawiki.conf /etc/apache2/
+COPY apache/restbase.conf /etc/apache2/
 RUN echo "Include /etc/apache2/mediawiki.conf" >> /etc/apache2/apache2.conf
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/apache/mediawiki.conf
+++ b/apache/mediawiki.conf
@@ -18,10 +18,6 @@ LimitRequestBody 220200960
   </VirtualHost>
 </IfModule>
 
-# Expose REST API at /api/rest_v1/
-ProxyPassInterpolateEnv On
-ProxyPass /api/rest_v1/ ${MEDIAWIKI_RESTBASE_URL}/ interpolate
-
 <Directory /var/www/html>
   # Use of .htaccess files exposes a lot of security risk,
   # disable them and put all the necessary configuration here instead.

--- a/apache/restbase.conf
+++ b/apache/restbase.conf
@@ -1,0 +1,3 @@
+# Expose REST API at /api/rest_v1/
+ProxyPassInterpolateEnv On
+ProxyPass /api/rest_v1/ ${MEDIAWIKI_RESTBASE_URL}/ interpolate

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,14 @@ if [ -z "$MEDIAWIKI_DB_HOST" ]; then
 	fi
 fi
 
+if [ -n "$MEDIAWIKI_RESTBASE_URL" ]; then
+	if ! grep -Fxq "Include /etc/apache2/restbase.conf" /etc/apache2/apache2.conf; then
+		echo "Include /etc/apache2/restbase.conf" >> /etc/apache2/apache2.conf
+	fi
+else
+	sed -i "/\b\(Include \/etc\/apache2\/restbase.conf\)\b/d" /etc/apache2/apache2.conf
+fi
+
 if [ -z "$MEDIAWIKI_DB_USER" ]; then
 	if [ "$MEDIAWIKI_DB_TYPE" = "mysql" ]; then
 		echo >&2 'info: missing MEDIAWIKI_DB_USER environment variable, defaulting to "root"'


### PR DESCRIPTION
Separate RESTBase apache ProxyPass configuration in
`mediawiki.conf` to a new file and add MEDIAWIKI_RESTBASE_URL
environment variable check to `docker-entrypoint.sh` to avoid
"AH00111: Config variable ${MEDIAWIKI_RESTBASE_URL} is not
defined" apache error.