### PR TITLE
fix: fix issue that symbolic links won't be automatically created

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -114,8 +114,17 @@ if ($_ENV['MEDIAWIKI_DB_TYPE'] == 'mysql') {
 EOPHP
 
 cd /var/www/html
-# FIXME: Keep php files out of the doc root.
-ln -s /usr/src/mediawiki/* .
+
+if ! [ -e index.php -a -e includes/DefaultSettings.php ]; then
+	echo >&2 "MediaWiki not found in $(pwd) - copying now..."
+
+	if [ "$(ls -A)" ]; then
+		echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+		( set -x; ls -A; sleep 10 )
+	fi
+	tar cf - --one-file-system -C /usr/src/mediawiki . | tar xf -
+	echo >&2 "Complete! MediaWiki has been successfully copied to $(pwd)"
+fi
 
 : ${MEDIAWIKI_SHARED:=/data}
 if [ -d "$MEDIAWIKI_SHARED" ]; then


### PR DESCRIPTION
 fix issue that symbolic links won't be automatically created the respective file in shared volume, see details in 'Shared Volume' section of READEME file 