### PR TITLE
use stable dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid
+FROM debian:jessie
 MAINTAINER Gabriel Wicke <gwicke@wikimedia.org>
 
 # Waiting in antiticipation for built-time arguments


### PR DESCRIPTION
use a stable dist..

`debian:sid` is inherently _[unstable](https://www.debian.org/releases/sid/)_

#### It is not possible to build the image with the latest _sid_

````
+ apt-get install -y --no-install-recommends ca-certificates apache2 libapache2-mod-php5 php5-mysql php5-cli php5-gd php5-curl imagemagick netcat git
Reading package lists...
Building dependency tree...
Package php5-gd is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package php5-cli is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package php5-mysql is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package php5-curl is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package libapache2-mod-php5 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libapache2-mod-php5' has no installation candidate
E: Package 'php5-mysql' has no installation candidate
E: Package 'php5-cli' has no installation candidate
E: Package 'php5-gd' has no installation candidate
E: Package 'php5-curl' has no installation candidate

````