### PR TITLE
use latest MEDIAWIKI_VERSION? 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Gabriel Wicke <gwicke@wikimedia.org>
 
 # Waiting in antiticipation for built-time arguments
 # https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION wmf/1.27.0-wmf.9
+ENV MEDIAWIKI_VERSION wmf/1.29.0-wmf.9
 
 # XXX: Consider switching to nginx.
 RUN set -x; \


### PR DESCRIPTION
Update to the latest available (wmf) MEDIAWIKI_VERSION branch?

This seems to be inherently error prone.. The wmf branches disappear removing the possibility of recreating the image.
There should be some other way of fixing the version? 
