### PR TITLE
Change CustomSettings.php path to /data

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -196,7 +196,7 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 		"$MEDIAWIKI_ADMIN_USER"
 
         # Append inclusion of /compose_conf/CustomSettings.php
-        echo "@include('/conf/CustomSettings.php');" >> LocalSettings.php
+        echo "@include('/data/CustomSettings.php');" >> LocalSettings.php
 
 		# If we have a mounted share volume, move the LocalSettings.php to it
 		# so it can be restored if this container needs to be reinitiated


### PR DESCRIPTION
The documentation says:

> If a CustomSettings.php file exists in your data file, a require('/data/CustomSettings.php'); will be appended to the generated LocalSettings.php file.

But this isn't actually the case. In the docker-entrypoint.sh it is set to _/conf/CustomSettings.php_
This commit fixed that discrepance.