### PR TITLE
Include a core set of extensions by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,9 @@ RUN set -x; \
     && git submodule update --init --recursive SyntaxHighlight_GeSHi \
     && git submodule update --init --recursive Cite \
     && git submodule update --init --recursive Echo \
-    && git submodule update --init --recursive Flow
+    && git submodule update --init --recursive Flow \
+    && git submodule update --init --recursive PageImages \
+    && git submodule update --init --recursive TextExtracts
 
 
 COPY php.ini /usr/local/etc/php/conf.d/mediawiki.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,18 @@ RUN set -x; \
     && git submodule update --init skins \
     && git submodule update --init vendor \
     && cd extensions \
-    # VisualEditor
+    # Extensions
     # TODO: make submodules shallow clones?
-    && git submodule update --init VisualEditor \
-    && cd VisualEditor \
-    && git checkout $MEDIAWIKI_VERSION \
-    && git submodule update --init \
-    && cd .. \
-    && git submodule update --init Math
+    && git submodule update --init --recursive VisualEditor \
+    && git submodule update --init --recursive Math \
+    && git submodule update --init --recursive EventBus \
+    && git submodule update --init --recursive Scribunto \
+    && git submodule update --init --recursive ParserFunctions \
+    && git submodule update --init --recursive SyntaxHighlight_GeSHi \
+    && git submodule update --init --recursive Cite \
+    && git submodule update --init --recursive Echo \
+    && git submodule update --init --recursive Flow
+
 
 COPY php.ini /usr/local/etc/php/conf.d/mediawiki.ini
 

--- a/apache/mediawiki.conf
+++ b/apache/mediawiki.conf
@@ -27,11 +27,14 @@ LimitRequestBody 220200960
   RewriteBase /
   # Expose REST API at /api/rest_v1/
   RewriteCond %{ENV:MEDIAWIKI_RESTBASE_URL} "!^restbase-is-not-specified$"
-  RewriteRule ^api/rest_v1/(.*)$  %{ENV:MEDIAWIKI_RESTBASE_URL}/$1  [P]
-  RewriteRule ^index\.php$ - [L]
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteRule . /index.php [L]
+  RewriteRule ^api/rest_v1/(.*)$  %{ENV:MEDIAWIKI_RESTBASE_URL}/$1  [P,L]
+  RewriteRule ^w/(.*)$ %{DOCUMENT_ROOT}/$1 [L]
+  # Short url for wiki pages
+  RewriteRule ^wiki/(.*)?$ %{DOCUMENT_ROOT}/index.php [L]
+  RewriteRule ^wiki$ /wiki/ [R,L]
+  
+  # Redirect / to Main Page
+  RewriteRule ^$ /wiki/ [R,L]
 </Directory>
 
 <Directory /var/www/html/images>


### PR DESCRIPTION
While including all production extensions would use too much space at
around 430mb without git history, the handful of extensions selected
here should satisfy most user's needs at reasonable disk and bandwidth
cost.