### PR TITLE
1.30.0 and PHP 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM debian:sid
 MAINTAINER Gabriel Wicke <gwicke@wikimedia.org>
 
-# Waiting in antiticipation for built-time arguments
-# https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION wmf/1.27.0-wmf.9
+ENV MEDIAWIKI_VERSION wmf/1.30.0-wmf.2
 
 # XXX: Consider switching to nginx.
 RUN set -x; \
@@ -11,11 +9,13 @@ RUN set -x; \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         apache2 \
-        libapache2-mod-php5 \
-        php5-mysql \
-        php5-cli \
-        php5-gd \
-        php5-curl \
+        libapache2-mod-php7.1 \
+        php7.1-mysql \
+        php7.1-cli \
+        php7.1-gd \
+        php7.1-curl \
+        php7.1-mbstring \
+        php7.1-xml \
         imagemagick \
         netcat \
         git \
@@ -45,7 +45,9 @@ RUN set -x; \
     && git submodule update --init VisualEditor \
     && cd VisualEditor \
     && git checkout $MEDIAWIKI_VERSION \
-    && git submodule update --init
+    && git submodule update --init \
+    && cd .. \
+    && git submodule update --init Math
 
 COPY php.ini /usr/local/etc/php/conf.d/mediawiki.ini
 

--- a/apache/mediawiki.conf
+++ b/apache/mediawiki.conf
@@ -18,11 +18,6 @@ LimitRequestBody 220200960
   </VirtualHost>
 </IfModule>
 
-# Expose REST API at /api/rest_v1/
-RewriteEngine On
-RewriteCond ${MEDIAWIKI_RESTBASE_URL} "!^restbase-is-not-specified$"
-RewriteRule "^/api/rest_v1/(.*)$"  "${MEDIAWIKI_RESTBASE_URL}/$1"  [P]
-
 <Directory /var/www/html>
   # Use of .htaccess files exposes a lot of security risk,
   # disable them and put all the necessary configuration here instead.
@@ -30,6 +25,9 @@ RewriteRule "^/api/rest_v1/(.*)$"  "${MEDIAWIKI_RESTBASE_URL}/$1"  [P]
 
   RewriteEngine On
   RewriteBase /
+  # Expose REST API at /api/rest_v1/
+  RewriteCond %{ENV:MEDIAWIKI_RESTBASE_URL} "!^restbase-is-not-specified$"
+  RewriteRule ^api/rest_v1/(.*)$  %{ENV:MEDIAWIKI_RESTBASE_URL}/$1  [P]
   RewriteRule ^index\.php$ - [L]
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -83,7 +83,7 @@ if [ -z "$MEDIAWIKI_DB_PORT" ]; then
 fi
 
 # Wait for the DB to come up
-while [ `/bin/nc $MEDIAWIKI_DB_HOST $MEDIAWIKI_DB_PORT < /dev/null > /dev/null; echo $?` != 0 ]; do
+while [ `/bin/nc -w 1 $MEDIAWIKI_DB_HOST $MEDIAWIKI_DB_PORT < /dev/null > /dev/null; echo $?` != 0 ]; do
     echo "Waiting for database to come up at $MEDIAWIKI_DB_HOST:$MEDIAWIKI_DB_PORT..."
     sleep 1
 done
@@ -220,7 +220,7 @@ fi
 # script. If already up to date, it won't do anything, otherwise it will
 # migrate the database if necessary on container startup. It also will
 # verify the database connection is working.
-if [ -e "LocalSettings.php" -a $MEDIAWIKI_UPDATE = true ]; then
+if [ -e "LocalSettings.php" -a "$MEDIAWIKI_UPDATE" = 'true' ]; then
 	echo >&2 'info: Running maintenance/update.php';
 	php maintenance/update.php --quick --conf ./LocalSettings.php
 fi


### PR DESCRIPTION
Also:
- Set a short netcat network timeout while waiting for mysql to come up.
This is important when using Kubernetes services, as the request won't
fail quickly in that case.
- Fix /api/rest_v1/ rewrite rule.