### PR TITLE
Use PHP 7.0 for LTS

### DIFF
--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-apache
+FROM php:7.0-apache
 
 # System Dependencies.
 RUN apt-get update && apt-get install -y \
@@ -12,7 +12,7 @@ RUN docker-php-ext-install mbstring mysqli opcache intl
 
 # Install the default object cache.
 RUN pecl channel-update pecl.php.net \
-	&& pecl install apcu-4.0.11 \
+	&& pecl install apcu-5.1.8 \
 	&& docker-php-ext-enable apcu
 
 # set recommended PHP.ini settings


### PR DESCRIPTION
Per <https://www.mediawiki.org/wiki/Compatibility#PHP> 1.27 supports PHP 7.0,
and using 7.0 will likely give users a pretty big performance boost.

And update the apcu version to match the one in the legacy Dockerfile.