### PR TITLE
Add PGSQL support

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -2,13 +2,13 @@ FROM php:7.1-apache
 
 # System Dependencies.
 RUN apt-get update && apt-get install -y \
-		git \
+		git libpg-dev \
 		imagemagick \
 		libicu-dev \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install the PHP extensions we need
-RUN docker-php-ext-install mbstring mysqli opcache intl
+RUN docker-php-ext-install mbstring mysqli opcache intl pgsql
 
 # Install the default object cache.
 RUN pecl channel-update pecl.php.net \


### PR DESCRIPTION
Allow users to use PostgreSQL for testing purposes if desired as opposed to only MySQL. Useful for people who want to reflect their real environments without needing to modify the Dockerfile.