### PR TITLE
Install python to power syntax highlighting plugin

### DIFF
--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 		git \
 		imagemagick \
 		libicu-dev \
+		python \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install the PHP extensions we need

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 		git \
 		imagemagick \
 		libicu-dev \
+		# Required for SytaxHighlighting
 		python \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 		git \
 		imagemagick \
 		libicu-dev \
+		python \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install the PHP extensions we need

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 		git \
 		imagemagick \
 		libicu-dev \
+		# Required for SytaxHighlighting
 		python \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 		git \
 		imagemagick \
 		libicu-dev \
+		python \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # Install the PHP extensions we need

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 		git \
 		imagemagick \
 		libicu-dev \
+		# Required for SytaxHighlighting
 		python \
 	--no-install-recommends && rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
Current official mediawiki docker images cannot power SytaxHighlighting plugins based on pygments. That require to have python installed.