### PR TITLE
Update base image

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.1-apache-jessie
 
 # System Dependencies.
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
it's not building. i get this error:
E: Package 'libpng12-dev' has no installation candidate
should change base image to php:7.1-apache-jessie or php:7.1-apache-stretch (accordingly)