### PR TITLE
T197709  Upgrade PHP to 7.2

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.2-apache
 
 # System Dependencies.
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Since the `stable` version supports PHP 7.2, we should start using it.