### PR TITLE
adding RewriteMod to enable short url

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -38,6 +38,9 @@ ENV MEDIAWIKI_BRANCH REL1_31
 ENV MEDIAWIKI_VERSION 1.31.0
 ENV MEDIAWIKI_SHA512 50ad9303b0c0bd8380dea7489be18a4022d5b65a31961af8d36c3c9ff6d74cdf25e8e10137ef1e025b4287e9ee9b7e0bf4198ca342a46ab42915c91f1ddaf940
 
+# enable RewriteMod to enable short url
+RUN a2enmod rewrite
+
 # MediaWiki setup
 RUN curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz" -o mediawiki.tar.gz \
 	&& echo "${MEDIAWIKI_SHA512} *mediawiki.tar.gz" | sha512sum -c - \


### PR DESCRIPTION
RewriteMod is not enabled by default and short url is not possible. With this change it is possible to create a .htaccess file and insert it via volume to /var/www/html and make short URLs possible.
See https://www.mediawiki.org/wiki/Manual:Short_URL/Apache