### PR TITLE
Remove build dependencies

### DIFF
--- a/1.27/Dockerfile
+++ b/1.27/Dockerfile
@@ -1,13 +1,13 @@
 FROM php:7.1-apache
 
-# System Dependencies.
+# System dependencies
 RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-# Required for SyntaxHighlighting
+		# Required for SyntaxHighlighting
 		python \
 	; \
 	rm -rf /var/lib/apt/lists/*
@@ -34,7 +34,7 @@ RUN set -ex; \
 		apcu \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \

--- a/1.27/Dockerfile
+++ b/1.27/Dockerfile
@@ -1,21 +1,52 @@
 FROM php:7.1-apache
 
 # System Dependencies.
-RUN apt-get update && apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-		libicu-dev \
-		# Required for SyntaxHighlighting
+# Required for SyntaxHighlighting
 		python \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 # Install the PHP extensions we need
-RUN docker-php-ext-install mbstring mysqli opcache intl
-
-# Install the default object cache.
-RUN pecl channel-update pecl.php.net \
-	&& pecl install apcu-5.1.8 \
-	&& docker-php-ext-enable apcu
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libicu-dev \
+	; \
+	\
+	docker-php-ext-install \
+		intl \
+		mbstring \
+		mysqli \
+		opcache \
+	; \
+	\
+	pecl install apcu-5.1.16; \
+	docker-php-ext-enable \
+		apcu \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/1.30/Dockerfile
+++ b/1.30/Dockerfile
@@ -1,13 +1,13 @@
 FROM php:7.1-apache
 
-# System Dependencies.
+# System dependencies
 RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-# Required for SyntaxHighlighting
+		# Required for SyntaxHighlighting
 		python \
 	; \
 	rm -rf /var/lib/apt/lists/*
@@ -34,7 +34,7 @@ RUN set -ex; \
 		apcu \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \

--- a/1.30/Dockerfile
+++ b/1.30/Dockerfile
@@ -1,21 +1,52 @@
 FROM php:7.1-apache
 
 # System Dependencies.
-RUN apt-get update && apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-		libicu-dev \
-		# Required for SyntaxHighlighting
+# Required for SyntaxHighlighting
 		python \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 # Install the PHP extensions we need
-RUN docker-php-ext-install mbstring mysqli opcache intl
-
-# Install the default object cache.
-RUN pecl channel-update pecl.php.net \
-	&& pecl install apcu-5.1.8 \
-	&& docker-php-ext-enable apcu
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libicu-dev \
+	; \
+	\
+	docker-php-ext-install \
+		intl \
+		mbstring \
+		mysqli \
+		opcache \
+	; \
+	\
+	pecl install apcu-5.1.16; \
+	docker-php-ext-enable \
+		apcu \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/1.31/Dockerfile
+++ b/1.31/Dockerfile
@@ -1,13 +1,13 @@
 FROM php:7.2-apache
 
-# System Dependencies.
+# System dependencies
 RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-# Required for SyntaxHighlighting
+		# Required for SyntaxHighlighting
 		python3 \
 	; \
 	rm -rf /var/lib/apt/lists/*
@@ -34,7 +34,7 @@ RUN set -ex; \
 		apcu \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \

--- a/1.31/Dockerfile
+++ b/1.31/Dockerfile
@@ -1,21 +1,52 @@
 FROM php:7.2-apache
 
 # System Dependencies.
-RUN apt-get update && apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-		libicu-dev \
-		# Required for SyntaxHighlighting
+# Required for SyntaxHighlighting
 		python3 \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 # Install the PHP extensions we need
-RUN docker-php-ext-install mbstring mysqli opcache intl
-
-# Install the default object cache.
-RUN pecl channel-update pecl.php.net \
-	&& pecl install apcu \
-	&& docker-php-ext-enable apcu
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libicu-dev \
+	; \
+	\
+	docker-php-ext-install \
+		intl \
+		mbstring \
+		mysqli \
+		opcache \
+	; \
+	\
+	pecl install apcu-5.1.16; \
+	docker-php-ext-enable \
+		apcu \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/1.32/Dockerfile
+++ b/1.32/Dockerfile
@@ -1,21 +1,52 @@
 FROM php:7.2-apache
 
 # System Dependencies.
-RUN apt-get update && apt-get install -y \
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-		libicu-dev \
-		# Required for SyntaxHighlighting
+# Required for SyntaxHighlighting
 		python3 \
-	--no-install-recommends && rm -r /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 # Install the PHP extensions we need
-RUN docker-php-ext-install mbstring mysqli opcache intl
-
-# Install the default object cache.
-RUN pecl channel-update pecl.php.net \
-	&& pecl install apcu \
-	&& docker-php-ext-enable apcu
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libicu-dev \
+	; \
+	\
+	docker-php-ext-install \
+		intl \
+		mbstring \
+		mysqli \
+		opcache \
+	; \
+	\
+	pecl install apcu-5.1.16; \
+	docker-php-ext-enable \
+		apcu \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # Enable Short URLs
 RUN a2enmod rewrite \

--- a/1.32/Dockerfile
+++ b/1.32/Dockerfile
@@ -1,13 +1,13 @@
 FROM php:7.2-apache
 
-# System Dependencies.
+# System dependencies
 RUN set -ex; \
 	\
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		git \
 		imagemagick \
-# Required for SyntaxHighlighting
+		# Required for SyntaxHighlighting
 		python3 \
 	; \
 	rm -rf /var/lib/apt/lists/*
@@ -34,7 +34,7 @@ RUN set -ex; \
 		apcu \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \


### PR DESCRIPTION
`libicu-dev` is only needed to build the PHP extensions, but not during runtime. This snipped is used in many other PHP images (e.g. [wordpress](https://github.com/docker-library/wordpress/blob/master/Dockerfile-debian.template)).
I also updated APCu to the current version.