### PR TITLE
Add template and update.sh

### DIFF
--- a/1.31/Dockerfile
+++ b/1.31/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux; \
 		opcache \
 	; \
 	\
-	pecl install apcu-5.1.17; \
+	pecl install APCu-5.1.18; \
 	docker-php-ext-enable \
 		apcu \
 	; \
@@ -49,6 +49,7 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
+
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
@@ -66,14 +67,34 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.31
-ENV MEDIAWIKI_BRANCH REL1_31
 ENV MEDIAWIKI_VERSION 1.31.8
-ENV MEDIAWIKI_SHA512 f5de72a060177bf444dd27e148c8b94224e5aeee9497169ca57a692ce9e8fb89dd7c2f503e2f6e4d035128b6e62a414a654edc467c5e7e3a347eb805d9ab9e93
 
 # MediaWiki setup
 RUN set -eux; \
+	fetchDeps=" \
+		gnupg \
+		dirmngr \
+	"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	\
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz" -o mediawiki.tar.gz; \
-	echo "${MEDIAWIKI_SHA512} *mediawiki.tar.gz" | sha512sum -c -; \
+	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
+	export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://www.mediawiki.org/keys/keys.txt
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
+		441276E9CCD15F44F6D97D18C119E1A64D70938E \
+		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \
+		1D98867E82982C8FE0ABC25F9B69B3109D3BB7B0 \
+	; \
+	gpg --batch --verify mediawiki.tar.gz.sig mediawiki.tar.gz; \
 	tar -x --strip-components=1 -f mediawiki.tar.gz; \
-	rm mediawiki.tar.gz; \
-	chown -R www-data:www-data extensions skins cache images
+	gpgconf --kill all; \
+	rm -r "$GNUPGHOME" mediawiki.tar.gz.sig mediawiki.tar.gz; \
+	chown -R www-data:www-data extensions skins cache images; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*
+
+CMD ["apache2-foreground"]

--- a/1.33/Dockerfile
+++ b/1.33/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux; \
 		opcache \
 	; \
 	\
-	pecl install apcu-5.1.17; \
+	pecl install APCu-5.1.18; \
 	docker-php-ext-enable \
 		apcu \
 	; \
@@ -53,12 +53,12 @@ RUN set -eux; \
 RUN set -eux; \
 	a2enmod rewrite; \
 	{ \
-		echo '<Directory /var/www/html>'; \
-		echo '  RewriteEngine On'; \
-		echo '  RewriteCond %{REQUEST_FILENAME} !-f'; \
-		echo '  RewriteCond %{REQUEST_FILENAME} !-d'; \
-		echo '  RewriteRule ^ %{DOCUMENT_ROOT}/index.php [L]'; \
-		echo '</Directory>'; \
+		echo "<Directory /var/www/html>"; \
+		echo "  RewriteEngine On"; \
+		echo "  RewriteCond %{REQUEST_FILENAME} !-f"; \
+		echo "  RewriteCond %{REQUEST_FILENAME} !-d"; \
+		echo "  RewriteRule ^ %{DOCUMENT_ROOT}/index.php [L]"; \
+		echo "</Directory>"; \
 	} > "$APACHE_CONFDIR/conf-available/short-url.conf"; \
 	a2enconf short-url
 
@@ -79,14 +79,34 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.33
-ENV MEDIAWIKI_BRANCH REL1_33
 ENV MEDIAWIKI_VERSION 1.33.4
-ENV MEDIAWIKI_SHA512 e37280b4c14bfdae3480b8f99672da5c93761f4f80019104d5df24affe0c8447881c6ff85f32d16381ee74a3ce7a083f4dda2e0a24bd6687fbf0b41f11f0564f
 
 # MediaWiki setup
 RUN set -eux; \
+	fetchDeps=" \
+		gnupg \
+		dirmngr \
+	"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	\
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz" -o mediawiki.tar.gz; \
-	echo "${MEDIAWIKI_SHA512} *mediawiki.tar.gz" | sha512sum -c -; \
+	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
+	export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://www.mediawiki.org/keys/keys.txt
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
+		441276E9CCD15F44F6D97D18C119E1A64D70938E \
+		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \
+		1D98867E82982C8FE0ABC25F9B69B3109D3BB7B0 \
+	; \
+	gpg --batch --verify mediawiki.tar.gz.sig mediawiki.tar.gz; \
 	tar -x --strip-components=1 -f mediawiki.tar.gz; \
-	rm mediawiki.tar.gz; \
-	chown -R www-data:www-data extensions skins cache images
+	gpgconf --kill all; \
+	rm -r "$GNUPGHOME" mediawiki.tar.gz.sig mediawiki.tar.gz; \
+	chown -R www-data:www-data extensions skins cache images; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*
+
+CMD ["apache2-foreground"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-FROM php:7.3-apache
+FROM php:%%PHP_VERSION%%-%%VARIANT%%
 
 # System dependencies
 RUN set -eux; \
@@ -30,7 +30,7 @@ RUN set -eux; \
 		opcache \
 	; \
 	\
-	pecl install APCu-5.1.18; \
+	pecl install APCu-%%APCU_VERSION%%; \
 	docker-php-ext-enable \
 		apcu \
 	; \
@@ -48,19 +48,7 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
-
-# Enable Short URLs
-RUN set -eux; \
-	a2enmod rewrite; \
-	{ \
-		echo "<Directory /var/www/html>"; \
-		echo "  RewriteEngine On"; \
-		echo "  RewriteCond %{REQUEST_FILENAME} !-f"; \
-		echo "  RewriteCond %{REQUEST_FILENAME} !-d"; \
-		echo "  RewriteRule ^ %{DOCUMENT_ROOT}/index.php [L]"; \
-		echo "</Directory>"; \
-	} > "$APACHE_CONFDIR/conf-available/short-url.conf"; \
-	a2enconf short-url
+%%VARIANT_EXTRAS%%
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -78,8 +66,8 @@ RUN set -eux; \
 	chown -R www-data:www-data /var/www/data
 
 # Version
-ENV MEDIAWIKI_MAJOR_VERSION 1.34
-ENV MEDIAWIKI_VERSION 1.34.2
+ENV MEDIAWIKI_MAJOR_VERSION %%MEDIAWIKI_MAJOR_VERSION%%
+ENV MEDIAWIKI_VERSION %%MEDIAWIKI_VERSION%%
 
 # MediaWiki setup
 RUN set -eux; \
@@ -109,4 +97,4 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \
 	rm -rf /var/lib/apt/lists/*
 
-CMD ["apache2-foreground"]
+CMD ["%%CMD%%"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is the Git repo of the Docker [official image](https://docs.docker.com/dock
 
 The full readme is generated over in [docker-library/docs](https://github.com/docker-library/docs), specifically in [docker-library/docs/mediawiki](https://github.com/docker-library/docs/tree/master/mediawiki).
 
+Do not edit the `Dockerfile`s directly. Changes should be made in the `Dockerfile-*.template` files and applied by running `update.sh`.
+
 See a change merged here that doesn't show up on the Docker Hub yet? Check [the "library/mediawiki" manifest file in the docker-library/official-images repo](https://github.com/docker-library/official-images/blob/master/library/mediawiki), especially [PRs with the "library/mediawiki" label on that repo](https://github.com/docker-library/official-images/labels/library%2Fmediawiki). For more information about the official images process, see the [docker-library/official-images readme](https://github.com/docker-library/official-images/blob/master/README.md).
 
 Please file bug reports on [Phabricator](https://phabricator.wikimedia.org/project/view/3094/) and not on GitHub.

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+mediawikiReleases=( "$@" )
+if [ ${#mediawikiReleases[@]} -eq 0 ]; then
+	mediawikiReleases=( 1.*/ )
+fi
+mediawikiReleases=( "${mediawikiReleases[@]%/}" )
+
+declare -A phpVersion=(
+	[default]='7.3'
+	[1.31]='7.2'
+	[1.33]='7.2'
+)
+
+declare -A peclVersions=(
+	[APCu]="5.1.18"
+)
+
+function mediawiki_version() {
+	git ls-remote --tags https://github.com/wikimedia/mediawiki.git \
+		| cut -d/ -f3 \
+		| grep -viE '[a-z]' \
+		| tr -d '^{}' \
+		| sort -V \
+		| grep -E "^$1" \
+		| tail -1
+}
+
+declare -A variantExtras=(
+	[apache]='\n# Enable Short URLs\nRUN set -eux; \\\n\ta2enmod rewrite; \\\n\t{ \\\n\t\techo \"<Directory /var/www/html>\"; \\\n\t\techo \"  RewriteEngine On\"; \\\n\t\techo \"  RewriteCond %{REQUEST_FILENAME} !-f\"; \\\n\t\techo \"  RewriteCond %{REQUEST_FILENAME} !-d\"; \\\n\t\techo \"  RewriteRule ^ %{DOCUMENT_ROOT}/index.php [L]\"; \\\n\t\techo \"</Directory>\"; \\\n\t} > \"$APACHE_CONFDIR/conf-available/short-url.conf\"; \\\n\ta2enconf short-url'
+	[fpm]=''
+	[fpm-alpine]=''
+)
+declare -A variantCmds=(
+	[apache]='apache2-foreground'
+	[fpm]='php-fpm'
+	[fpm-alpine]='php-fpm'
+)
+declare -A variantBases=(
+	[apache]='debian'
+	[fpm]='debian'
+	[fpm-alpine]='alpine'
+)
+
+for mediawikiRelease in "${mediawikiReleases[@]}"; do
+	mediawikiReleaseDir="$mediawikiRelease"
+	mediawikiVersion="$(mediawiki_version $mediawikiRelease)"
+	phpVersion=${phpVersion[$mediawikiRelease]-${phpVersion[default]}}
+
+	#for variant in apache fpm fpm-alpine; do
+	for variant in apache; do
+		#dir="$mediawikiReleaseDir/$variant"
+		#mkdir -p "$dir"
+		dir="${mediawikiRelease}"
+
+		extras="${variantExtras[$variant]}"
+		cmd="${variantCmds[$variant]}"
+		base="${variantBases[$variant]}"
+
+		case "$mediawikiRelease" in
+			1.31 )
+				extras=""
+				;;
+		esac
+
+		sed -r \
+			-e 's!%%MEDIAWIKI_VERSION%%!'"$mediawikiVersion"'!g' \
+			-e 's!%%MEDIAWIKI_MAJOR_VERSION%%!'"$mediawikiRelease"'!g' \
+			-e 's!%%PHP_VERSION%%!'"$phpVersion"'!g' \
+			-e 's!%%VARIANT%%!'"$variant"'!g' \
+			-e 's!%%APCU_VERSION%%!'"${peclVersions[APCu]}"'!g' \
+			-e 's@%%VARIANT_EXTRAS%%@'"$extras"'@g' \
+			-e 's!%%CMD%%!'"$cmd"'!g' \
+			"Dockerfile-${base}.template" > "$dir/Dockerfile"
+	done
+done


### PR DESCRIPTION
Fixes https://phabricator.wikimedia.org/T197220

Notes:
- fixes #64
- this is already based on top of #65
- switched from SHA checksum to GnuPG signature verification
- requires Bash >= 4.0
- prepares for https://phabricator.wikimedia.org/T197684
- @docker-library-bot could run `update.sh` periodically (needs write access)