### PR TITLE
Remove obsolete 'opcache.fast_shutdown' setting

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -57,7 +57,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # SQLite Directory Setup


### PR DESCRIPTION
This has been removed in PHP 7.2.
This repo only uses php 7.2 and later.

https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.fast-shutdown