### PR TITLE
Switch MW 1.35 to PHP 7.4

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -12,7 +12,7 @@ mediawikiReleases=( "${mediawikiReleases[@]%/}" )
 declare -A phpVersion=(
 	[default]='7.3'
 	[1.31]='7.2'
-	[1.33]='7.2'
+	[1.35]='7.4'
 )
 
 declare -A peclVersions=(


### PR DESCRIPTION
Note that the 1.33 entry was obsolete since there is no 1.33 build.

If for whatever reason using the latest rather than the oldest PHP version is not desired in the 1.35 image, would an alternative image (mediawiki:1.35-php7.4) be welcome?