### PR TITLE
 MW 1.35 PHP 7.4 support

### DIFF
--- a/1.31/apache/Dockerfile
+++ b/1.31/apache/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
+		libonig-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.31/fpm-alpine/Dockerfile
+++ b/1.31/fpm-alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
 		icu-dev \
+		oniguruma-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.31/fpm/Dockerfile
+++ b/1.31/fpm/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
+		libonig-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.34/apache/Dockerfile
+++ b/1.34/apache/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
+		libonig-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.34/fpm-alpine/Dockerfile
+++ b/1.34/fpm-alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
 		icu-dev \
+		oniguruma-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.34/fpm/Dockerfile
+++ b/1.34/fpm/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
+		libonig-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.35/apache/Dockerfile
+++ b/1.35/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache
+FROM php:7.4-apache
 
 # System dependencies
 RUN set -eux; \
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
+		libonig-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.35/fpm-alpine/Dockerfile
+++ b/1.35/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-alpine
+FROM php:7.4-fpm-alpine
 
 # System dependencies
 RUN set -eux; \
@@ -16,6 +16,7 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
 		icu-dev \
+		oniguruma-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/1.35/fpm/Dockerfile
+++ b/1.35/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 # System dependencies
 RUN set -eux; \
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
+		libonig-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -16,6 +16,7 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
 		icu-dev \
+		oniguruma-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -21,6 +21,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
+		libonig-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/update.sh
+++ b/update.sh
@@ -11,6 +11,7 @@ mediawikiReleases=( "${mediawikiReleases[@]%/}" )
 
 declare -A phpVersion=(
 	[default]='7.3'
+	[1.35]='7.4'
 )
 
 declare -A peclVersions=(


### PR DESCRIPTION
Additional changes are required compared to https://github.com/wikimedia/mediawiki-docker/pull/88

Specifically, building PHP 7.4 with mbstring requires adding the `oniguruma` dev library (https://www.php.net/manual/en/mbstring.installation.php).