### PR TITLE
Update Mediawiki 1.31 to php73 because php72 is EOL

### DIFF
--- a/1.31/apache/Dockerfile
+++ b/1.31/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.3-apache
 
 # System dependencies
 RUN set -eux; \

--- a/1.31/fpm-alpine/Dockerfile
+++ b/1.31/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm-alpine
+FROM php:7.3-fpm-alpine
 
 # System dependencies
 RUN set -eux; \

--- a/1.31/fpm/Dockerfile
+++ b/1.31/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.3-fpm
 
 # System dependencies
 RUN set -eux; \

--- a/update.sh
+++ b/update.sh
@@ -11,8 +11,6 @@ mediawikiReleases=( "${mediawikiReleases[@]%/}" )
 
 declare -A phpVersion=(
 	[default]='7.3'
-	[1.31]='7.2'
-	[1.33]='7.2'
 )
 
 declare -A peclVersions=(


### PR DESCRIPTION
Because PHP 7.2 went EOL upstream, some GitHub Actions failed when trying to update the Docker-Image. See https://github.com/docker-library/official-images/pull/9328

The official php72 image got removed here: https://github.com/docker-library/official-images/commit/707f80e4887abc32746f2f6740aa1eb4eb227b12#diff-bb01db07e940d90a0a7611d371b641a531f572c2b944e184a2a0eb89da050aae

This commit also cleans up some leftovers from 1.33