### PR TITLE
Update Mediawiki to 1.35.2 & 1.31.14

### DIFF
--- a/1.31/apache/Dockerfile
+++ b/1.31/apache/Dockerfile
@@ -66,7 +66,7 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.31
-ENV MEDIAWIKI_VERSION 1.31.12
+ENV MEDIAWIKI_VERSION 1.31.14
 
 # MediaWiki setup
 RUN set -eux; \

--- a/1.31/fpm-alpine/Dockerfile
+++ b/1.31/fpm-alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.31
-ENV MEDIAWIKI_VERSION 1.31.12
+ENV MEDIAWIKI_VERSION 1.31.14
 
 # MediaWiki setup
 RUN set -eux; \

--- a/1.31/fpm/Dockerfile
+++ b/1.31/fpm/Dockerfile
@@ -66,7 +66,7 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.31
-ENV MEDIAWIKI_VERSION 1.31.12
+ENV MEDIAWIKI_VERSION 1.31.14
 
 # MediaWiki setup
 RUN set -eux; \

--- a/1.35/apache/Dockerfile
+++ b/1.35/apache/Dockerfile
@@ -81,7 +81,7 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.35
-ENV MEDIAWIKI_VERSION 1.35.1
+ENV MEDIAWIKI_VERSION 1.35.2
 
 # MediaWiki setup
 RUN set -eux; \

--- a/1.35/fpm-alpine/Dockerfile
+++ b/1.35/fpm-alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.35
-ENV MEDIAWIKI_VERSION 1.35.1
+ENV MEDIAWIKI_VERSION 1.35.2
 
 # MediaWiki setup
 RUN set -eux; \

--- a/1.35/fpm/Dockerfile
+++ b/1.35/fpm/Dockerfile
@@ -66,7 +66,7 @@ RUN set -eux; \
 
 # Version
 ENV MEDIAWIKI_MAJOR_VERSION 1.35
-ENV MEDIAWIKI_VERSION 1.35.1
+ENV MEDIAWIKI_VERSION 1.35.2
 
 # MediaWiki setup
 RUN set -eux; \


### PR DESCRIPTION
https://lists.wikimedia.org/pipermail/mediawiki-announce/2021-April/000272.html - Security and maintenance release: 1.31.13 / 1.35.2
https://lists.wikimedia.org/pipermail/mediawiki-announce/2021-April/000273.html - Maintenance release: 1.31.14