### PR TITLE
Switch keyserver to keyserver.ubuntu.com

### DIFF
--- a/1.31/apache/Dockerfile
+++ b/1.31/apache/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.31/fpm-alpine/Dockerfile
+++ b/1.31/fpm-alpine/Dockerfile
@@ -71,7 +71,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.31/fpm/Dockerfile
+++ b/1.31/fpm/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.35/apache/Dockerfile
+++ b/1.35/apache/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.35/fpm-alpine/Dockerfile
+++ b/1.35/fpm-alpine/Dockerfile
@@ -71,7 +71,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.35/fpm/Dockerfile
+++ b/1.35/fpm/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.36/apache/Dockerfile
+++ b/1.36/apache/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.36/fpm-alpine/Dockerfile
+++ b/1.36/fpm-alpine/Dockerfile
@@ -71,7 +71,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/1.36/fpm/Dockerfile
+++ b/1.36/fpm/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -71,7 +71,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -83,7 +83,7 @@ RUN set -eux; \
 	curl -fSL "https://releases.wikimedia.org/mediawiki/${MEDIAWIKI_MAJOR_VERSION}/mediawiki-${MEDIAWIKI_VERSION}.tar.gz.sig" -o mediawiki.tar.gz.sig; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg key from https://www.mediawiki.org/keys/keys.txt
-	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
 		D7D6767D135A514BEB86E9BA75682B08E8A3FEC4 \
 		441276E9CCD15F44F6D97D18C119E1A64D70938E \
 		F7F780D82EBFB8A56556E7EE82403E59F9F8CD79 \


### PR DESCRIPTION
The sks-keyservers pool is gone now, so switch to keyserver.ubuntu.com
per
<https://github.com/docker-library/faq#openpgp--gnupg-keys-and-verification>.