### PR TITLE
Fix 'update.sh' so it generates 'short-url.conf' for 1.31/apache

### DIFF
--- a/1.31/apache/Dockerfile
+++ b/1.31/apache/Dockerfile
@@ -51,6 +51,21 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
+# Enable Short URLs
+RUN set -eux; \
+	a2enmod rewrite; \
+	{ \
+		echo "<Directory /var/www/html>"; \
+		echo "  RewriteEngine On"; \
+		echo "  RewriteCond %{REQUEST_FILENAME} !-f"; \
+		echo "  RewriteCond %{REQUEST_FILENAME} !-d"; \
+		echo "  RewriteRule ^ %{DOCUMENT_ROOT}/index.php [L]"; \
+		echo "</Directory>"; \
+	} > "$APACHE_CONFDIR/conf-available/short-url.conf"; \
+	a2enconf short-url
+
+# Enable AllowEncodedSlashes for VisualEditor
+RUN sed -i "s/<\/VirtualHost>/\tAllowEncodedSlashes NoDecode\n<\/VirtualHost>/" "$APACHE_CONFDIR/sites-available/000-default.conf"
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+readlink='readlink'
+sed='sed'
+
+if [[ $(uname -s) != Linux ]]; then
+	# use the GNU versions explicitly
+	readlink='greadlink'
+	sed='gsed'
+fi
+
+# set TRACE=1 in the environment to trace execution
+if (( ${TRACE:-} )); then set -x; fi
+
+cd "$(dirname "$($readlink -f "$BASH_SOURCE")")"
 
 mediawikiReleases=( "$@" )
 if [ ${#mediawikiReleases[@]} -eq 0 ]; then
@@ -55,13 +67,7 @@ for mediawikiRelease in "${mediawikiReleases[@]}"; do
 		cmd="${variantCmds[$variant]}"
 		base="${variantBases[$variant]}"
 
-		case "$mediawikiRelease" in
-			1.31 )
-				extras=""
-				;;
-		esac
-
-		sed -r \
+		$sed -r \
 			-e 's!%%MEDIAWIKI_VERSION%%!'"$mediawikiVersion"'!g' \
 			-e 's!%%MEDIAWIKI_MAJOR_VERSION%%!'"$mediawikiRelease"'!g' \
 			-e 's!%%PHP_VERSION%%!'"$phpVersion"'!g' \


### PR DESCRIPTION
- update.sh has been corrected to generate the `short-url.conf` Apache config  that is necessary for the 1.31 image to be functional out of the box

- use `#!/usr/bin/env bash` in the shebang line for macOS, where `/usr/bin/bash`  is too old, and causes `update.sh` to terminate on error

- run the GNU versions of `sed` and `realpath` on non-Linux, otherwise `update.sh`  terminates on error

- resolves [T289093](https://phabricator.wikimedia.org/T289093)