### PR TITLE
Add calendar PHP extension

### DIFF
--- a/1.37/apache/Dockerfile
+++ b/1.37/apache/Dockerfile
@@ -25,6 +25,7 @@ RUN set -eux; \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \
+		calendar \
 		intl \
 		mbstring \
 		mysqli \


### PR DESCRIPTION
The `calendar` extension seems to be a (new?) requirement in the `/var/www/html/composer.json` file.
Using `composer` without it will otherwise fail with the message:
> Root composer.json requires PHP extension ext-calendar * but it is missing from your system. Install or enable PHP's calendar extension.