### PR TITLE
fixes for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,10 @@
 name: Docker Build
-
 on:
   pull_request:
   push:
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -16,5 +13,5 @@ jobs:
         type: [apache, fpm, fpm-alpine]
 
     steps:
-    - uses: actions/checkout@v1
-    - run: docker build ./${{ matrix.version }}/${{ matrix.type }}
+      - uses: actions/checkout@v4
+      - run: docker build ./${{ matrix.version }}/${{ matrix.type }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,11 +9,12 @@ jobs:
     container: debian:bookworm
     env:
       GH_TOKEN: ${{ github.token }}
+
     steps:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install --yes --no-install-recommends python3 git gh ca-certificates
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run update
         run: |
           gh repo set-default wikimedia/mediawiki-docker

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apt-get update && apt-get install --yes --no-install-recommends python3 git gh
+          apt-get update && apt-get install --yes --no-install-recommends python3 git gh ca-certificates
       - uses: actions/checkout@v3
       - name: Run update
         run: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is the Git repo of the Docker [official image](https://docs.docker.com/dock
 
 The full readme is generated over in [docker-library/docs](https://github.com/docker-library/docs), specifically in [docker-library/docs/mediawiki](https://github.com/docker-library/docs/tree/master/mediawiki).
 
-Do not edit the `Dockerfile`s directly. Changes should be made in the `Dockerfile-*.template` files and applied by running `update.sh`.
+Do not edit the `Dockerfile`s directly. Changes should be made in the `Dockerfile-*.template` files and applied by running `update.py`.
+The project is also running `update.py` via a scheduled github action once per day.
 
 See a change merged here that doesn't show up on the Docker Hub yet? Check [the "library/mediawiki" manifest file in the docker-library/official-images repo](https://github.com/docker-library/official-images/blob/master/library/mediawiki), especially [PRs with the "library/mediawiki" label on that repo](https://github.com/docker-library/official-images/labels/library%2Fmediawiki). For more information about the official images process, see the [docker-library/official-images readme](https://github.com/docker-library/official-images/blob/master/README.md).
 


### PR DESCRIPTION
It seems like the update action fails (see https://github.com/wikimedia/mediawiki-docker/actions/runs/6345587761/job/17237820236#step:4:55) because of an invalid cert. According to https://github.com/google/go-github/issues/1049 this is most likely caused by missing ca-certificates which this PR also installs in the pipeline.

While we are at it this also updates the readme to correctly reflect the current state of things, reformats the yaml a bit and updates the checkout action. 😊 

This was locally tested to fix the issue using https://github.com/nektos/act/
