### PR TITLE
checkout the full git history with actions/checkout@v4

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,9 @@ jobs:
         run: |
           apt-get update && apt-get install --yes --no-install-recommends python3 git gh ca-certificates
       - uses: actions/checkout@v4
+        with:
+          # check out the full git history
+          fetch_depth: 0
       - name: Run update
         run: |
           gh repo set-default wikimedia/mediawiki-docker


### PR DESCRIPTION
This fixes an error that was not caught by local testing:
> must be run from inside a git repository
> Error: Process completed with exit code 1.

See i.e. https://github.com/wikimedia/mediawiki-docker/actions/runs/6527365499/job/17722124059#step:5:10