### PR TITLE
explicitly set the git safe directory

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run update
         run: |
+          # without re-setting the safe.directory config options all git
+          # commands error out, even though this should be already be set by
+          # actions/checkout.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           gh repo set-default wikimedia/mediawiki-docker
           git checkout -b auto-update
           ./update.py --commit --pr


### PR DESCRIPTION
This fixes an error that was not caught by local testing in #132:
> must be run from inside a git repository
> Error: Process completed with exit code 1.

The error can be observed in the scheduled pipeline runs: https://github.com/wikimedia/mediawiki-docker/actions/runs/6527365499/job/17722124059#step:5:10

This is maybe just a workaround for a bug in the checkout action, which
already should set the correct safe directory according to its
documentation.

This was verified to run and fix the problem [here](https://github.com/christian-heusel/mediawiki-docker/actions/runs/6534884920/job/17743092090) which ran a slightly modified version of this patch for testing purposes (https://github.com/christian-heusel/mediawiki-docker/commit/3f451d2ad966a30792050a153b74a4bdd86b6f4f).
