### PR TITLE
Install LuaSandbox PECL extension

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -16,6 +16,7 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
 		icu-dev \
+		lua5.1-dev \
 		oniguruma-dev \
 	; \
 	\
@@ -28,8 +29,10 @@ RUN set -eux; \
 	; \
 	\
 	pecl install APCu-%%APCU_VERSION%%; \
+	pecl install LuaSandbox-%%LUASANDBOX_VERSION%%; \
 	docker-php-ext-enable \
 		apcu \
+		luasandbox \
 	; \
 	rm -r /tmp/pear; \
 	\

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -22,6 +22,7 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \
+		liblua5.1-0-dev \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \
@@ -33,8 +34,10 @@ RUN set -eux; \
 	; \
 	\
 	pecl install APCu-%%APCU_VERSION%%; \
+	pecl install LuaSandbox-%%LUASANDBOX_VERSION%%; \
 	docker-php-ext-enable \
 		apcu \
+		luasandbox \
 	; \
 	rm -r /tmp/pear; \
 	\

--- a/update.py
+++ b/update.py
@@ -10,6 +10,7 @@ PHP_VERSIONS = {
     "default": "8.1",
 }
 APCU_VERSION = "5.1.23"
+LUASANDBOX_VERSION = "4.1.2"
 VARIANTS = ["apache", "fpm", "fpm-alpine"]
 ROOT_DIR = Path(__file__).parent
 
@@ -91,6 +92,7 @@ def main():
                 .replace("%%MEDIAWIKI_VERSION%%", latest)
                 .replace("%%VARIANT%%", variant)
                 .replace("%%APCU_VERSION%%", APCU_VERSION)
+                .replace("%%LUASANDBOX_VERSION%%", LUASANDBOX_VERSION)
                 .replace(
                     "%%CMD%%",
                     "apache2-foreground" if variant == "apache" else "php-fpm",


### PR DESCRIPTION
Scribunto ships with a statically linked lua5.1 binary, but it doesn't work on alpine because of the glibc dependency.

We can install the LuaSandbox PECL extension to fix the situation for alpine users and give everyone else a performance boost.

Bug: T285882