### PR TITLE
CI: Dynamically determine versions to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,31 @@ on:
   pull_request:
   push:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
+  lookup-versions:
+    runs-on: ubuntu-latest
+
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get current versions
+        id: versions
+        run: |
+          echo "versions=$(python -c 'import glob, json; print(json.dumps(glob.glob("1.*")))')" | tee $GITHUB_OUTPUT
+
   build:
     runs-on: ubuntu-latest
 
+    needs:
+      - lookup-versions
     strategy:
       matrix:
-        version: ['1.39', '1.41', '1.42']
+        version: ${{ fromJson(needs.lookup-versions.outputs.versions) }}
         type: [apache, fpm, fpm-alpine]
 
     steps:


### PR DESCRIPTION
I figured out this trick when working on SecureDrop (https://github.com/freedomofpress/securedrop/pull/7222), we can dynamically generate the values for the matrix so we don't have to update them. That's not really a big burden anyways, but this is kind of cool.

![Screenshot 2024-08-17 at 22-43-57 CI Dynamically determine versions to build · wikimedia_mediawiki-docker@51698df](https://github.com/user-attachments/assets/d3fae005-77fb-43b3-8dbe-0b2459723726)
