### PR TITLE
T376447: fix missing liblua5.1.so.0 warning

### DIFF
--- a/1.39/apache/Dockerfile
+++ b/1.39/apache/Dockerfile
@@ -16,9 +16,13 @@ RUN set -eux; \
 # Install the PHP extensions we need
 RUN set -eux; \
 	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		liblua5.1-0 \
+	; \
+	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
-	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \

--- a/1.39/fpm/Dockerfile
+++ b/1.39/fpm/Dockerfile
@@ -16,9 +16,13 @@ RUN set -eux; \
 # Install the PHP extensions we need
 RUN set -eux; \
 	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		liblua5.1-0 \
+	; \
+	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
-	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \

--- a/1.41/apache/Dockerfile
+++ b/1.41/apache/Dockerfile
@@ -16,9 +16,13 @@ RUN set -eux; \
 # Install the PHP extensions we need
 RUN set -eux; \
 	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		liblua5.1-0 \
+	; \
+	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
-	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \

--- a/1.41/fpm/Dockerfile
+++ b/1.41/fpm/Dockerfile
@@ -16,9 +16,13 @@ RUN set -eux; \
 # Install the PHP extensions we need
 RUN set -eux; \
 	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		liblua5.1-0 \
+	; \
+	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
-	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \

--- a/1.42/apache/Dockerfile
+++ b/1.42/apache/Dockerfile
@@ -16,9 +16,13 @@ RUN set -eux; \
 # Install the PHP extensions we need
 RUN set -eux; \
 	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		liblua5.1-0 \
+	; \
+	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
-	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \

--- a/1.42/fpm/Dockerfile
+++ b/1.42/fpm/Dockerfile
@@ -16,9 +16,13 @@ RUN set -eux; \
 # Install the PHP extensions we need
 RUN set -eux; \
 	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		liblua5.1-0 \
+	; \
+	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
-	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -16,9 +16,13 @@ RUN set -eux; \
 # Install the PHP extensions we need
 RUN set -eux; \
 	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		liblua5.1-0 \
+	; \
+	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
-	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		libicu-dev \
 		libonig-dev \


### PR DESCRIPTION
As it turns out the liblua5 shared object is needed for runtime aswell
and having it missing produces a warning i.e. when running "php -v".
Fix this by installing it before the build time dependencies that are
to be removed later on.

Fixes https://phabricator.wikimedia.org/T376447
